### PR TITLE
Updates to support migrating EC2 instances from RHEL 6 AMIs to RHEL 6 ELS AMI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ artifacts/
 __pycache__/
 *~
 .pytest_cache/
+ansible.log

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,6 @@
 
 instance_tag: 'rhel-6-els'
 key_pair_name: ''
+#aws_region:
 aws_ssl_enabled: true
-aws_ec2_url: 'https://ec2.{{ ansible_env.AWS_DEFAULT_REGION }}.amazonaws.com'
+#aws_ec2_url: 'https://ec2.{{ aws_region }}.amazonaws.com'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 # defaults file for rhel-6-els
+
+instance_tag: 'rhel-6-els'
+key_pair_name: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@
 
 instance_tag: 'rhel-6-els'
 key_pair_name: ''
+aws_ssl_enabled: true
+aws_ec2_url: 'https://ec2.{{ ansible_env.AWS_DEFAULT_REGION }}.amazonaws.com'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for rhel-6-els
 
 instance_tag: 'rhel-6-els'
-key_pair_name: ''
+#key_pair_name: ''
 #aws_region:
 aws_ssl_enabled: true
 #aws_ec2_url: 'https://ec2.{{ aws_region }}.amazonaws.com'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -62,5 +62,3 @@
   delegate_facts: true
   run_once: true
   register: tmp_private_key_md5
-  
-

--- a/tasks/get_instance_information.yml
+++ b/tasks/get_instance_information.yml
@@ -21,8 +21,11 @@
   community.aws.ec2_instance_info:
     aws_access_key: "{{ inject.aws_access_key | default(omit) }}"
     aws_secret_key: "{{ inject.aws_secret_key | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     profile: "{{ inject.profile | default(omit) }}"
     region: "{{ inject.region | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     filters:
       "tag:task": '{{ instance_tag }}'
   register: donor_instances_info

--- a/tasks/get_instance_information.yml
+++ b/tasks/get_instance_information.yml
@@ -24,18 +24,24 @@
     profile: "{{ inject.profile | default(omit) }}"
     region: "{{ inject.region | default(omit) }}"
     filters:
-      "tag:task": rhel-6-els
+      "tag:task": '{{ instance_tag }}'
   register: donor_instances_info
   delegate_to: 127.0.0.1
   delegate_facts: true
 
-- name: donor | Gather the detaijls related to the instance
+#- name: show instances
+#  debug:
+#    var: donor_instances_info
+
+- name: donor | Gather the details related to the instance
   ansible.builtin.set_fact:
     donor_conf_dict: {
     'az': "{{ item.1.placement.availability_zone }}",
     'key': "{{ item.1.key_name }}",
     'ip_address': "{{ item.1.private_ip_address }}",
     'subnet_id': "{{ item.1.subnet_id }}",
+    'instance_id': "{{ item.1.instance_id }}",
+    'root_volume_device_name': "{{ item.1.root_device_name }}",
     # 'security_groups': "{{ item.1.security_groups }}",
     # 'tags': "{{ item.1.tags }}",
     # 'id': "{{ item.1.instance_id }}",
@@ -49,12 +55,16 @@
   delegate_to: 127.0.0.1
   with_indexed_items: "{{ donor_instances_info.instances }}"
 
-- name: Convert instance config dictionary to list
-  ansible.builtin.set_fact:
-    donor_instance_conf: "{{ donor_config_dict.results }}"
-  delegate_to: 127.0.0.1
+#- name: Show donor config
+#  debug:
+#    var: donor_conf_dict
 
-- name: Convert instance config dictionary to list
-  ansible.builtin.set_fact:
-    donor_instance_conf: "{{ donor_config_dict.results | map(attributes='ansible_facts.instance_config_dict') | list }}"
-  delegate_to: 127.0.0.1
+#- name: Convert donor config dictionary to list
+#  ansible.builtin.set_fact:
+#    donor_instance_conf: "{{ donor_config_dict.results }}"
+#  delegate_to: 127.0.0.1
+
+#- name: Convert instance config dictionary to list
+#  ansible.builtin.set_fact:
+#    donor_instance_conf: "{{ donor_config_dict.results | map(attributes='ansible_facts.instance_config_dict') | list }}"
+#  delegate_to: 127.0.0.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
    # limitations under the License.                                           #
    # ######################################################################## #
 
-# tasks file for rhel-6-els
+# Find the RHEL 6 ELS AMI and register variables for it
 - include_tasks: rhel_6_els_ami.yml
   # provides var:rhel_6_els_ami
 
@@ -23,19 +23,24 @@
   include_tasks: get_instance_information.yml
   # provides rhel6_instance_... for details related to the donor
 
-- name: create an isolated vpc for the instance cloning
-  include_tasks: build_isolated_vpc.yml
+#- name: create an isolated vpc for the instance cloning
+#  include_tasks: build_isolated_vpc.yml
   # provides donor_instance_info
 
-- name: Create snapshot 1 of the donor instance
-  include_tasks: snapshot_one.yml
-  # creates and provides the snapshot id.
+# We cannot loop over a block so we have to loop over a single include
+- name: Migrate an instance
+  include_tasks: migrate_instance.yml
+  vars:
+    donor_instance: '{{ instance_index }}'
+  loop: '{{ donor_instances_info.instances }}'
+  loop_control:
+    loop_var: instance_index
 
-- name: Create a rhel-6-els target instance
-  include_tasks: launch_rhel_6_els_instance.yml
+#- name: Create a rhel-6-els target instance
+#  include_tasks: launch_rhel_6_els_instance.yml
   
-- name: Create a surrogate instance
-  include_tasks: initalize_surrogate_instance.yml
+#- name: Create a surrogate instance
+#  include_tasks: initalize_surrogate_instance.yml
   
 #   notify: set the instance id as a fact
 #     # (needed for stop/start action)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,10 +47,10 @@
 #   notify: set the root_volume as a fact
 #     # (needed for snapshot actions)
 
-- name: enumerate the extra volumes attached to the instance
-  debug:
-    msg: "-*- TODO -*- enumerate the extra volumes attached to the instance"
-
+#- name: enumerate the extra volumes attached to the instance
+#  debug:
+#    msg: "-*- TODO -*- enumerate the extra volumes attached to the instance"
+#
 #   name: Stop the rhel-6-els target instance
 #   debug:
 #     msg: "-*- TODO -*- Stop the rhel-6-els target instance"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Migrate an instance
   include_tasks: migrate_instance.yml
   vars:
-    donor_instance: '{{ donor_instances_info.instances[instance_index] }}'
+    donor_instance: '{{ instance_index }}'
   loop: '{{ donor_instances_info.instances }}'
   loop_control:
     loop_var: instance_index

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,20 @@
    # limitations under the License.                                           #
    # ######################################################################## #
 
+#- name: Refetch replacement instance info
+#  delegate_to: localhost
+#  community.aws.ec2_instance_info:
+#    instance_ids:
+#      - 'i-0dd82eff8d609390e'
+#  register: replacement_instance
+#
+#- name: Show replacement instance info again
+#  debug:
+#    var: replacement_instance
+#
+#- fail:
+#    msg: "stop here"
+
 # Find the RHEL 6 ELS AMI and register variables for it
 - include_tasks: rhel_6_els_ami.yml
   # provides var:rhel_6_els_ami
@@ -46,58 +60,3 @@
 #     # (needed for stop/start action)
 #   notify: set the root_volume as a fact
 #     # (needed for snapshot actions)
-
-#- name: enumerate the extra volumes attached to the instance
-#  debug:
-#    msg: "-*- TODO -*- enumerate the extra volumes attached to the instance"
-#
-#   name: Stop the rhel-6-els target instance
-#   debug:
-#     msg: "-*- TODO -*- Stop the rhel-6-els target instance"
-# - name: Detach the target instance root volume
-#   debug:
-#     msg: "-*- TODO -*-  Detach the target instance root volume"
-#   notify: Attach target vol to surrogate
-# - name: Create donor volume 1 from snapshot 1
-#   debug:
-#     msg: "-*- TODO -*-  Create donor volume 1 from snapshot 1"
-# - name: Attach donor volume to surrogate instance
-#   debug:
-#     msg: "-*- TODO -*-  Attach donor volume to surrogate instance"
-# - name: Copy content from donor volume to target instance.
-#   debug:
-#     msg: "-*- TODO -*-  Copy content from donor volume to target instance."
-# - name: Destroy donor volume 1 from donor instance
-#   debug:
-#     msg: "-*- TODO -*-  Destroy donor volume 1 from donor instance"
-# - name: Stop donor instance for final snapshot
-#   debug:
-#     msg: "-*- TODO -*-  Stop donor instance for final snapshot"
-#   # notify: -*- TODO -*- create snapshot 2 from donor root volume
-#   # (set timeout based on the maintenance window)
-#   # notify: -*- TODO -*- Start instance to continue providing service
-# - name: Create donor volume 2 from snapshot 2
-#   debug:
-#     msg: "-*- TODO -*-  Create donor volume 2 from snapshot 2"
-# - name: Attach the donor volume 2 to the surrogate instance
-#   debug:
-#     msg: "-*- TODO -*-  Attach the donor volume 2 to the surrogate instance"
-# - name: dd the content from donor volume 2 to target vol
-#   debug:
-#     msg: "-*- TODO -*-  dd the content from donor volume 2 to target vol"
-#   # (set timeout based on the maintenance window)
-#   # notify: detach the volumes from the surrogate
-# - name: terminate the surrogate instance
-#   debug:
-#     msg: "-*- TODO -*-  terminate the surrogate instance"
-# - name: attach the target volume to the target instance (rhel-6-els)
-#   debug:
-#     msg: "-*- TODO -*-  attach the target volume to the target instance (rhel-6-els)"
-#   # notify: -*- TODO -*- register an image from the target instance
-# - name: Attach any additional volumes to the target instance
-#   debug:
-#     msg: "-*- TODO -*-  Attach any additional volumes to the target instance"
-#   # notify: -*- TODO -*- Create Image from donor instance (no waiting)
-# - name: Start the target instance
-#   debug:
-#     msg: "-*- TODO -*-  Start the target instance

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Migrate an instance
   include_tasks: migrate_instance.yml
   vars:
-    donor_instance: '{{ instance_index }}'
+    donor_instance: '{{ donor_instances_info.instances[instance_index] }}'
   loop: '{{ donor_instances_info.instances }}'
   loop_control:
     loop_var: instance_index

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -9,6 +9,7 @@
   community.aws.ec2_instance:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -36,6 +37,7 @@
   community.aws.ec2_instance_info:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -53,6 +55,7 @@
   community.aws.ec2_instance:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -66,6 +69,7 @@
   amazon.aws.ec2_vol:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -78,6 +82,7 @@
   amazon.aws.ec2_vol:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -113,6 +118,7 @@
   community.aws.ec2_instance:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -22,17 +22,24 @@
     #group_id: '{{ donor_instance. }}'
     #instance_profile_name: '{{ donor_instance. }}'
     #instance_tags: '{{ donor_instance. }}'
-    state: present
+    state: running
   register: replacement_instance
-
-- name: Show replacement instance info
-  debug:
-    var: replacement_instance
 
 - name: Wait for replace instance to finish booting
   wait_for:
     timeout: 60
   delegate_to: localhost
+
+- name: Refetch replacement instance info
+  delegate_to: localhost
+  community.aws.ec2_instance_info:
+    instance_ids:
+      - '{{ replacement_instance.instances[0].instance_id }}'
+  register: replacement_instance
+
+- name: Show replacement instance info again
+  debug:
+    var: replacement_instance
 
 - name: Stop replacement instance
   delegate_to: localhost
@@ -90,3 +97,14 @@
   delegate_to: localhost
   debug:
     var: my_snaps
+
+- name: Start replacement instance
+  delegate_to: localhost
+  community.aws.ec2_instance:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    state: running
+    instance_ids:
+      - '{{ replacement_instance.instances[0].instance_id }}'

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -2,7 +2,7 @@
 
 - name: Show donor instance info
   debug:
-    var: rhel_6_els_ami
+    var: donor_instance
 
 - name: Create replacement instance
   delegate_to: localhost
@@ -44,6 +44,17 @@
     state: stopped
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'
+
+- name: Refetch replacement instance info
+  delegate_to: localhost
+  community.aws.ec2_instance_info:
+    instance_ids:
+      - '{{ replacement_instance.instances[0].instance_id }}'
+  register: replacement_instance
+
+- name: Show replacement instance info again
+  debug:
+    var: replacement_instance
 
 - name: Detach root volume from replacement instance
   delegate_to: localhost

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -4,9 +4,6 @@
   debug:
     var: donor_instance
 
-- fail:
-    msg: "stop here"
-
 - name: Create replacement instance
   delegate_to: localhost
   community.aws.ec2_instance:

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -2,13 +2,68 @@
 
 - name: Show donor instance info
   debug:
-    var: donor_instance
+    var: rhel_6_els_ami
+
+- name: Create replacement instance
+  delegate_to: localhost
+  community.aws.ec2_instance:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    #availability_zone: '{{ donor_instance.placement.availability_zone }}'
+    ebs_optimized: '{{ donor_instance.ebs_optimized }}'
+    key_name: '{{ donor_instance.key_name }}'
+    instance_type: '{{ donor_instance.instance_type }}'
+    image_id: '{{ rhel_6_els_ami.image_id }}'
+    wait: true
+    name: "ELS replacement "
+    vpc_subnet_id: '{{ donor_instance.subnet_id }}'
+    #group_id: '{{ donor_instance. }}'
+    #instance_profile_name: '{{ donor_instance. }}'
+    #instance_tags: '{{ donor_instance. }}'
+    state: present
+  register: replacement_instance
+
+- name: Show replacement instance info
+  debug:
+    var: replacement_instance
+
+- name: Wait for replace instance to finish booting
+  wait_for:
+    timeout: 60
+  delegate_to: localhost
+
+- name: Stop replacement instance
+  delegate_to: localhost
+  community.aws.ec2_instance:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    state: stopped
+    instance_ids:
+      - '{{ replacement_instance[0].instance_id }}'
+
+- name: Detach root volume from replacement instance
+  delegate_to: localhost
+  amazon.aws.ec2_vol:
+    id: '{{ replacement_instance[0].block_device_mappings[0].ebs.volume_id }}'
+    instance: None
+
+- name: Delete root volume from replacement instance
+  delegate_to: localhost
+  amazon.aws.ec2_vol:
+    id: '{{ replacement_instance[0].block_device_mappings[0].ebs.volume_id }}'
+    state: absent
 
 - name: Initialize my_snaps
+  delegate_to: localhost
   set_fact:
     my_snaps: []
 
 - name: Initialize my_vols
+  delegate_to: localhost
   set_fact:
     my_vols: []
 
@@ -21,49 +76,7 @@
     loop_var: block_device_index
 
 - name: Show my_snaps
+  delegate_to: localhost
   debug:
     var: my_snaps
 
-
-# Possible steps....
-# Create replacement instance
-# Wait for start
-# Stop the replacement instance
-# Attach all the same security groups
-# Detach and delete the root volume of the replacement instance
-# Attach all the volumes to the replacement instance
-
-
-- name: Create replacement instance
-  community.aws.ec2_instance:
-    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
-    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
-    #profile: "{{ inject.profile | default(omit) }}"
-    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    zone: '{{ donor_instance.placement.availability_zone }}'
-    ebs_optimized: '{{ donor_instance.ebs_optimized }}'
-    key_name: '{{ donor_instance.key_name }}'
-    instance_type: '{{ donor_instance.instance_type }}'
-    image: '{{ rhel_6_els_ami }}'
-    wait: true
-    vpc_subnet_id: '{{ donor_instance.subnet_id }}'
-    #group_id: '{{ donor_instance. }}'
-    #instance_profile_name: '{{ donor_instance. }}'
-    #instance_tags: '{{ donor_instance. }}'
-    state: present
-  register: replacement_instance
-
-- name: Wait for replace instance to finish booting
-  wait_for:
-    timeout: 60
-  delegate_to: localhost
-
-- name: Create replacement instance
-  community.aws.ec2_instance:
-    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
-    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
-    #profile: "{{ inject.profile | default(omit) }}"
-    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    state: stopped
-    instance_ids:
-      - {{ replacement_instance.

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -17,7 +17,7 @@
     instance_type: '{{ donor_instance.instance_type }}'
     image_id: '{{ rhel_6_els_ami.image_id }}'
     wait: true
-    name: "ELS replacement "
+    name: "ELS replacement {{ donor_instance.instance_id }}"
     vpc_subnet_id: '{{ donor_instance.subnet_id }}'
     #group_id: '{{ donor_instance. }}'
     #instance_profile_name: '{{ donor_instance. }}'
@@ -43,18 +43,18 @@
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     state: stopped
     instance_ids:
-      - '{{ replacement_instance[0].instance_id }}'
+      - '{{ replacement_instance.instances[0].instance_id }}'
 
 - name: Detach root volume from replacement instance
   delegate_to: localhost
   amazon.aws.ec2_vol:
-    id: '{{ replacement_instance[0].block_device_mappings[0].ebs.volume_id }}'
+    id: '{{ replacement_instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
     instance: None
 
 - name: Delete root volume from replacement instance
   delegate_to: localhost
   amazon.aws.ec2_vol:
-    id: '{{ replacement_instance[0].block_device_mappings[0].ebs.volume_id }}'
+    id: '{{ replacement_instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
     state: absent
 
 - name: Initialize my_snaps

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -11,7 +11,8 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    #availability_zone: '{{ donor_instance.placement.availability_zone }}'
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     ebs_optimized: '{{ donor_instance.ebs_optimized }}'
     key_name: '{{ donor_instance.key_name }}'
     instance_type: '{{ donor_instance.instance_type }}'
@@ -33,6 +34,12 @@
 - name: Refetch replacement instance info
   delegate_to: localhost
   community.aws.ec2_instance_info:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'
   register: replacement_instance
@@ -48,6 +55,8 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     state: stopped
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'
@@ -55,6 +64,12 @@
 - name: Refetch replacement instance info
   delegate_to: localhost
   community.aws.ec2_instance_info:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'
   register: replacement_instance
@@ -66,12 +81,24 @@
 - name: Detach root volume from replacement instance
   delegate_to: localhost
   amazon.aws.ec2_vol:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     id: '{{ replacement_instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
     instance: None
 
 - name: Delete root volume from replacement instance
   delegate_to: localhost
   amazon.aws.ec2_vol:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     id: '{{ replacement_instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
     state: absent
 
@@ -105,6 +132,8 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     state: running
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -79,4 +79,3 @@
   delegate_to: localhost
   debug:
     var: my_snaps
-

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -4,6 +4,9 @@
   debug:
     var: donor_instance
 
+- fail:
+    msg: "stop here"
+
 - name: Create replacement instance
   delegate_to: localhost
   community.aws.ec2_instance:
@@ -11,7 +14,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     ebs_optimized: '{{ donor_instance.ebs_optimized }}'
     key_name: '{{ donor_instance.key_name }}'
@@ -38,7 +41,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'
@@ -55,7 +58,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     state: stopped
     instance_ids:
@@ -68,7 +71,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     id: '{{ replacement_instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
     instance: None
@@ -80,7 +83,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     id: '{{ replacement_instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
     state: absent
@@ -115,7 +118,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     state: running
     instance_ids:

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Show donor instance info
+  debug:
+    var: donor_instance
+
+- name: Initialize my_snaps
+  set_fact:
+    my_snaps: []
+
+- name: Create snapshots of the donor instance volumes
+  include_tasks: snapshot_one.yml
+  vars:
+    block_device: '{{ block_device_index }}'
+  loop: '{{ donor_instance.block_device_mappings }}'
+  loop_control:
+    loop_var: block_device_index
+
+- name: Show my_snaps
+  debug:
+    var: my_snaps

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -8,6 +8,10 @@
   set_fact:
     my_snaps: []
 
+- name: Initialize my_vols
+  set_fact:
+    my_vols: []
+
 - name: Create snapshots of the donor instance volumes
   include_tasks: snapshot_one.yml
   vars:
@@ -19,3 +23,47 @@
 - name: Show my_snaps
   debug:
     var: my_snaps
+
+
+# Possible steps....
+# Create replacement instance
+# Wait for start
+# Stop the replacement instance
+# Attach all the same security groups
+# Detach and delete the root volume of the replacement instance
+# Attach all the volumes to the replacement instance
+
+
+- name: Create replacement instance
+  community.aws.ec2_instance:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    zone: '{{ donor_instance.placement.availability_zone }}'
+    ebs_optimized: '{{ donor_instance.ebs_optimized }}'
+    key_name: '{{ donor_instance.key_name }}'
+    instance_type: '{{ donor_instance.instance_type }}'
+    image: '{{ rhel_6_els_ami }}'
+    wait: true
+    vpc_subnet_id: '{{ donor_instance.subnet_id }}'
+    #group_id: '{{ donor_instance. }}'
+    #instance_profile_name: '{{ donor_instance. }}'
+    #instance_tags: '{{ donor_instance. }}'
+    state: present
+  register: replacement_instance
+
+- name: Wait for replace instance to finish booting
+  wait_for:
+    timeout: 60
+  delegate_to: localhost
+
+- name: Create replacement instance
+  community.aws.ec2_instance:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    state: stopped
+    instance_ids:
+      - {{ replacement_instance.

--- a/tasks/migrate_instance.yml
+++ b/tasks/migrate_instance.yml
@@ -61,23 +61,6 @@
     instance_ids:
       - '{{ replacement_instance.instances[0].instance_id }}'
 
-- name: Refetch replacement instance info
-  delegate_to: localhost
-  community.aws.ec2_instance_info:
-    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
-    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
-    #profile: "{{ inject.profile | default(omit) }}"
-    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
-    validate_certs: '{{ aws_ssl_enabled }}'
-    instance_ids:
-      - '{{ replacement_instance.instances[0].instance_id }}'
-  register: replacement_instance
-
-- name: Show replacement instance info again
-  debug:
-    var: replacement_instance
-
 - name: Detach root volume from replacement instance
   delegate_to: localhost
   amazon.aws.ec2_vol:

--- a/tasks/rhel_6_els_ami.yml
+++ b/tasks/rhel_6_els_ami.yml
@@ -1,9 +1,9 @@
 - name: Register the RHEL-6-ELS image ID
   amazon.aws.ec2_ami_info:
-    aws_access_key: "{{ inject.aws_access_key | default(omit) }}"
-    aws_secret_key: "{{ inject.aws_secret_key | default(omit) }}"
-    profile: "{{ inject.profile | default(omit) }}"
-    region: "{{ inject.region | default(omit) }}"
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     owners: 679593333241
     filters:
       product-code: 65nbrx0tx3wb0wnchpwz5yvm
@@ -16,6 +16,10 @@
   ansible.builtin.set_fact:
     rhel_6_els_ami: >-
       {{ rhel_6_els_amis.images | selectattr('name', 'defined') | sort(attribute='name') | last }}
+
+- name: Show RHEL 6 ELS AMI
+  debug:
+    var: rhel_6_els_ami
 
 # Build the instance and when you build the instance add it to an inventory group
 #   that doesn't include the rhel6 instance.

--- a/tasks/rhel_6_els_ami.yml
+++ b/tasks/rhel_6_els_ami.yml
@@ -4,7 +4,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     owners: 679593333241
     filters:

--- a/tasks/rhel_6_els_ami.yml
+++ b/tasks/rhel_6_els_ami.yml
@@ -9,10 +9,11 @@
       product-code: 65nbrx0tx3wb0wnchpwz5yvm
       product-code.type: marketplace
       name: RHEL-6.10ELS_HVM*
-  delegate_to: 127.0.0.1
+  delegate_to: localhost
   register: rhel_6_els_amis
 
 - name: Identify the most recently published image
+  delegate_to: localhost
   ansible.builtin.set_fact:
     rhel_6_els_ami: >-
       {{ rhel_6_els_amis.images | selectattr('name', 'defined') | sort(attribute='name') | last }}

--- a/tasks/rhel_6_els_ami.yml
+++ b/tasks/rhel_6_els_ami.yml
@@ -4,6 +4,8 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     owners: 679593333241
     filters:
       product-code: 65nbrx0tx3wb0wnchpwz5yvm

--- a/tasks/rhel_6_els_ami.yml
+++ b/tasks/rhel_6_els_ami.yml
@@ -2,6 +2,7 @@
   amazon.aws.ec2_ami_info:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -76,4 +76,4 @@
     instance: '{{ replacement_instance.instances[0].instance_id }}'
     id: '{{ my_vol.volume_id }}'
     device_name: '{{ block_device.device_name }}'
-    delete_on_terminate: '{{ block_device.ebs.delete_on_termination }}'
+    delete_on_termination: '{{ block_device.ebs.delete_on_termination }}'

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -19,7 +19,7 @@
 
 - name: Show block device mappings
   debug:
-    var: block_device.ebs.volume_id
+    var: block_device
 
 - name: "Gather vol {{ block_device.ebs.volume_id }} info"
   delegate_to: localhost
@@ -27,6 +27,10 @@
     filters:
       volume-id: '{{ block_device.ebs.volume_id }}'
   register: donor_volume
+
+- name: Show vol info
+  debug:
+    var: donor_volume
 
 - name: "Create Snapshot of {{ donor_instance.instance_id }} vol: {{ block_device.ebs.volume_id }}" 
   delegate_to: localhost
@@ -47,7 +51,7 @@
   set_fact:
     my_snaps: "{{ my_snaps + [donor_snapshot] }}"
 
-- name: "Create volume for {{ donor_snapshot }}"
+- name: "Create volume for {{ donor_snapshot.snapshot_id }}"
   delegate_to: localhost
   amazon.aws.ec2_vol:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
@@ -56,9 +60,9 @@
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: "{{ ec2_url | default(omit) }}"
     snapshot: '{{ donor_snapshot.snapshot_id }}'
-    volume_type: '{{ donor_volume[0].type }}'
+    volume_type: '{{ donor_volume.volumes[0].type }}'
     volume_size: '{ donor_snapshot.volume_size }}'
-    zone: '{{ donor_volume[0].zone }}'
+    zone: '{{ donor_volume.volumes[0].zone }}'
     tags: '{{ donor_snapshot.tags }}'
   register: my_vol
 
@@ -69,7 +73,7 @@
 - name: Attach volume to the replacement host
   delegate_to: localhost
   amazon.aws.ec2_vol:
-    instance: {{ donor_instance.instance_id }}
-    id: {{ my_vol.volume_id }}
-    device_name: {{ block_device.device_name}}
-    delete_on_terminate: {{ block_device.ebs.delete_on_termination }}
+    instance: '{{ replacement_instance.instances[0].instance_id }}'
+    id: '{{ my_vol.volume_id }}'
+    device_name: '{{ block_device.device_name }}'
+    delete_on_terminate: '{{ block_device.ebs.delete_on_termination }}'

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -22,40 +22,48 @@
 # - name: Identify the Root volume of the rhel-6-instance
 #   amazon.aws.ec2_metadata_facts:
 
-- name: Get the instance root volume
-  amazon.aws.ec2_vol_info:
-    aws_access_key: "{{ inject.aws_access_key | default(omit) }}"
-    aws_secret_key: "{{ inject.aws_secret_key | default(omit) }}"
-    profile: "{{ inject.profile | default(omit) }}"
-    region: "{{ inject.region | default(omit) }}"
-    filters:
-      attachment.instance-id: "{{ donor_instance_id }}"
-      attachment.device: "{{ donor_instance_root_volume_device_name }}"
-  delegate_to: 127.0.0.1
-  register: donor_instance_root_volume_info
+#- name: Get the instance root volume
+#  amazon.aws.ec2_vol_info:
+#    aws_access_key: "{{ inject.aws_access_key | default(omit) }}"
+#    aws_secret_key: "{{ inject.aws_secret_key | default(omit) }}"
+#    profile: "{{ inject.profile | default(omit) }}"
+#    region: "{{ inject.region | default(omit) }}"
+#    filters:
+#      attachment.instance-id: "{{ donor_instance_id }}"
+#      attachment.device: "{{ donor_instance_root_volume_device_name }}"
+#  delegate_to: 127.0.0.1
+#  register: donor_instance_root_volume_info
+#
 
-- name: "Create Snapshot for {{ donor_instance_id }}"
+- name: Show block device mappings
+  debug:
+    var: block_device.ebs.volume_id
+
+- name: "Create Snapshot for {{ donor_instance.instance_id }}"
   amazon.aws.ec2_snapshot:
-    aws_access_key: "{{ inject.aws_access_key | default(omit) }}"
-    aws_secret_key: "{{ inject.aws_secret_key | default(omit) }}"
-    profile: "{{ inject.profile | default(omit) }}"
-    region: "{{ inject.region | default(omit) }}"
-    volume_id: "{{ donor_instance_root_volume_info.volumes[0].id }}"
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    volume_id: '{{ block_device.ebs.volume_id }}'
     last_snapshot_min_age: 120
-    description: "Snapshot one destined for rhel-6-els from {{ donor_instance_id }}"
-    snapshot_tags: "{{ inject.tags | combine({ 'Name': donor_instance_id, 'els_status': 'active', 'els_stage':'one'}) }}"
+    description: "Snapshot of {{ block_device.ebs.volume_id }} destined for rhel-6-els from {{ donor_instance.instance_id }}"
+    #snapshot_tags: "{{ inject.tags | combine({ 'Name': donor_instance.instance_id, 'els_status': 'active', 'els_stage':'one'}) }}"
     wait: yes
+    wait_timeout: 7200
   delegate_to: 127.0.0.1
   register: donor_snapshot
-  async: 7200
-  poll: 0
 
-- name: Wait for the snapshot to complete
-  ansible.builtin.async_status:
-    jid: "{{ donor_snapshot.ansible_job_id }}"
-  register: snapshot_1_job
-  until: snapshot_1_job.finished
-  retries: 300
-  delay: 20
-  delegate_to: 127.0.0.1
-  delegate_facts: true
+- name: Add snapshot to the main list
+  set_fact:
+    my_snaps: "{{ my_snaps + [donor_snapshot] }}"
+
+#- name: Wait for the snapshot to complete
+#  ansible.builtin.async_status:
+#    jid: "{{ donor_snapshot.ansible_job_id }}"
+#  register: snapshot_1_job
+#  until: snapshot_1_job.finished
+#  retries: 300
+#  delay: 20
+#  delegate_to: 127.0.0.1
+#  delegate_facts: true

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -24,6 +24,12 @@
 - name: "Gather vol {{ block_device.ebs.volume_id }} info"
   delegate_to: localhost
   amazon.aws.ec2_vol_info:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     filters:
       volume-id: '{{ block_device.ebs.volume_id }}'
   register: donor_volume
@@ -39,6 +45,8 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     volume_id: '{{ block_device.ebs.volume_id }}'
     last_snapshot_min_age: 120
     description: "Snapshot of {{ block_device.ebs.volume_id }} destined for rhel-6-els from {{ donor_instance.instance_id }}"
@@ -58,7 +66,8 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: "{{ ec2_url | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     snapshot: '{{ donor_snapshot.snapshot_id }}'
     volume_type: '{{ donor_volume.volumes[0].type }}'
     volume_size: '{{ donor_snapshot.volume_size }}'
@@ -73,6 +82,12 @@
 - name: Attach volume to the replacement host
   delegate_to: localhost
   amazon.aws.ec2_vol:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: '{{ aws_ec2_url }}'
+    validate_certs: '{{ aws_ssl_enabled }}'
     instance: '{{ replacement_instance.instances[0].instance_id }}'
     id: '{{ my_vol.volume_id }}'
     device_name: '{{ block_device.device_name }}'

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -26,6 +26,7 @@
   amazon.aws.ec2_vol_info:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -43,6 +44,7 @@
   amazon.aws.ec2_snapshot:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -64,6 +66,7 @@
   amazon.aws.ec2_vol:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'
@@ -84,6 +87,7 @@
   amazon.aws.ec2_vol:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    security_token: "{{ ansible_env.AWS_SESSION_TOKEN | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
     ec2_url: '{{ aws_ec2_url | default(omit) }}'

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -28,7 +28,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     filters:
       volume-id: '{{ block_device.ebs.volume_id }}'
@@ -45,7 +45,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     volume_id: '{{ block_device.ebs.volume_id }}'
     last_snapshot_min_age: 120
@@ -66,7 +66,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     snapshot: '{{ donor_snapshot.snapshot_id }}'
     volume_type: '{{ donor_volume.volumes[0].type }}'
@@ -86,7 +86,7 @@
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
     #profile: "{{ inject.profile | default(omit) }}"
     region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
-    ec2_url: '{{ aws_ec2_url }}'
+    ec2_url: '{{ aws_ec2_url | default(omit) }}'
     validate_certs: '{{ aws_ssl_enabled }}'
     instance: '{{ replacement_instance.instances[0].instance_id }}'
     id: '{{ my_vol.volume_id }}'

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -39,7 +39,13 @@
   debug:
     var: block_device.ebs.volume_id
 
-- name: "Create Snapshot for {{ donor_instance.instance_id }}"
+- name: "Gather vol {{ block_device.ebs.volume_id }} info"
+  amazon.aws.ec2_vol_info:
+    filters:
+      volume-id: '{{ block_device.ebs.volume_id }}'
+  register: donor_volume
+
+- name: "Create Snapshot of {{ donor_instance.instance_id }} vol: {{ block_device.ebs.volume_id }}" 
   amazon.aws.ec2_snapshot:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
@@ -58,12 +64,21 @@
   set_fact:
     my_snaps: "{{ my_snaps + [donor_snapshot] }}"
 
-#- name: Wait for the snapshot to complete
-#  ansible.builtin.async_status:
-#    jid: "{{ donor_snapshot.ansible_job_id }}"
-#  register: snapshot_1_job
-#  until: snapshot_1_job.finished
-#  retries: 300
-#  delay: 20
-#  delegate_to: 127.0.0.1
-#  delegate_facts: true
+- name: "Create volume for {{ donor_snapshot }}"
+  amazon.aws.ec2_vol:
+    aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
+    aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
+    #profile: "{{ inject.profile | default(omit) }}"
+    region: "{{ ansible_env.AWS_DEFAULT_REGION | default(omit) }}"
+    ec2_url: "{{ ec2_url | default(omit) }}"
+    snapshot: '{{ donor_snapshot.snapshot_id }}'
+    volume_type: '{{ donor_volume[0].type }}'
+    volume_size: '{ donor_snapshot.volume_size }}'
+    zone: '{{ donor_volume[0].zone }}'
+    tags: '{{ donor_snapshot.tags }}'
+  delegate_to: localhost
+  register: my_vol
+
+- name: Add volume to the main list
+  set_fact:
+    my_snaps: "{{ my_vols + [my_vol] }}"

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -41,7 +41,6 @@
     #snapshot_tags: "{{ inject.tags | combine({ 'Name': donor_instance.instance_id, 'els_status': 'active', 'els_stage':'one'}) }}"
     wait: yes
     wait_timeout: 7200
-  delegate_to: 127.0.0.1
   register: donor_snapshot
 
 - name: Add snapshot to the main list
@@ -61,7 +60,6 @@
     volume_size: '{ donor_snapshot.volume_size }}'
     zone: '{{ donor_volume[0].zone }}'
     tags: '{{ donor_snapshot.tags }}'
-  delegate_to: localhost
   register: my_vol
 
 - name: Add volume to the main list

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -17,35 +17,19 @@
    # limitations under the License.                                           #
    # ######################################################################## #
 
-# This next task has been replace by "get_instance_information.yml"
-# There is no reason to require login to the instance. This does.
-# - name: Identify the Root volume of the rhel-6-instance
-#   amazon.aws.ec2_metadata_facts:
-
-#- name: Get the instance root volume
-#  amazon.aws.ec2_vol_info:
-#    aws_access_key: "{{ inject.aws_access_key | default(omit) }}"
-#    aws_secret_key: "{{ inject.aws_secret_key | default(omit) }}"
-#    profile: "{{ inject.profile | default(omit) }}"
-#    region: "{{ inject.region | default(omit) }}"
-#    filters:
-#      attachment.instance-id: "{{ donor_instance_id }}"
-#      attachment.device: "{{ donor_instance_root_volume_device_name }}"
-#  delegate_to: 127.0.0.1
-#  register: donor_instance_root_volume_info
-#
-
 - name: Show block device mappings
   debug:
     var: block_device.ebs.volume_id
 
 - name: "Gather vol {{ block_device.ebs.volume_id }} info"
+  delegate_to: localhost
   amazon.aws.ec2_vol_info:
     filters:
       volume-id: '{{ block_device.ebs.volume_id }}'
   register: donor_volume
 
 - name: "Create Snapshot of {{ donor_instance.instance_id }} vol: {{ block_device.ebs.volume_id }}" 
+  delegate_to: localhost
   amazon.aws.ec2_snapshot:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
@@ -65,6 +49,7 @@
     my_snaps: "{{ my_snaps + [donor_snapshot] }}"
 
 - name: "Create volume for {{ donor_snapshot }}"
+  delegate_to: localhost
   amazon.aws.ec2_vol:
     aws_access_key: "{{ ansible_env.AWS_ACCESS_KEY_ID | default(omit) }}"
     aws_secret_key: "{{ ansible_env.AWS_SECRET_ACCESS_KEY | default(omit) }}"
@@ -82,3 +67,11 @@
 - name: Add volume to the main list
   set_fact:
     my_snaps: "{{ my_vols + [my_vol] }}"
+
+- name: Attach volume to the replacement host
+  delegate_to: localhost
+  amazon.aws.ec2_vol:
+    instance: {{ donor_instance.instance_id }}
+    id: {{ my_vol.volume_id }}
+    device_name: {{ block_device.device_name}}
+    delete_on_terminate: {{ block_device.ebs.delete_on_termination }}

--- a/tasks/snapshot_one.yml
+++ b/tasks/snapshot_one.yml
@@ -61,7 +61,7 @@
     ec2_url: "{{ ec2_url | default(omit) }}"
     snapshot: '{{ donor_snapshot.snapshot_id }}'
     volume_type: '{{ donor_volume.volumes[0].type }}'
-    volume_size: '{ donor_snapshot.volume_size }}'
+    volume_size: '{{ donor_snapshot.volume_size }}'
     zone: '{{ donor_volume.volumes[0].zone }}'
     tags: '{{ donor_snapshot.tags }}'
   register: my_vol

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,5 @@
 ---
 - hosts: all
+  gather_facts: false
   roles:
     - ../aws_rh6_conv

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,4 @@
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: all
   roles:
-    - aws_rh6_conv
+    - ../aws_rh6_conv


### PR DESCRIPTION
I updated the role to support migrating instances from RHEL 6 AMIs to RHEL 6 ELS AMIs. I also added support for custom AWS API EC2 endpoints and STS API keys to support one of the target regions for this role.